### PR TITLE
Shorten default server cert expiration.

### DIFF
--- a/template_for_settings.cnf
+++ b/template_for_settings.cnf
@@ -53,7 +53,7 @@ sslsha="sha256"
 
 sslrootdays="7300"
 sslintdays="3650"
-sslsrvdays="800"
+sslsrvdays="396"
 
 
 


### PR DESCRIPTION
Chromium rejects certificates with an expiration more than 397 days in the future.